### PR TITLE
fix: reconcile verified runtimes without current link

### DIFF
--- a/src-tauri/src/backend_tests.rs
+++ b/src-tauri/src/backend_tests.rs
@@ -6,6 +6,10 @@ use crate::*;
 mod tests {
     use super::*;
 
+    fn normalized_fixture_source(source: &str) -> String {
+        source.replace("\r\n", "\n")
+    }
+
     fn test_profile(provider: &str) -> Profile {
         Profile {
             id: "profile-1".into(),
@@ -1785,7 +1789,7 @@ codexhub_test_sleep() {{ :; }}
 
     #[test]
     fn profile_apply_persists_confirmed_state_before_process_reload() {
-        let source = include_str!("services/profile_operations.rs");
+        let source = normalized_fixture_source(include_str!("services/profile_operations.rs"));
         let env_check = source
             .find("let api_key_env_present")
             .expect("API env verification");
@@ -1819,7 +1823,7 @@ codexhub_test_sleep() {{ :; }}
 
     #[test]
     fn install_runtime_reconcile_and_cleanup_order_is_stable() {
-        let source = include_str!("services/host_operations.rs");
+        let source = normalized_fixture_source(include_str!("services/host_operations.rs"));
         let reconcile_guard = source
             .find("let should_reconcile_runtime = successful_install.is_some() || has_runtime_recovery_floor")
             .expect("runtime recovery guard");
@@ -1854,7 +1858,8 @@ codexhub_test_sleep() {{ :; }}
         assert!(source[cleanup..].contains("action == RemoteCodexAction::Update"));
         assert!(source[cleanup..].contains("CodexReleaseCleanupPolicy::VerifiedOlderThan"));
         assert!(source[cleanup..].contains("CodexReleaseCleanupPolicy::ManagedOnly"));
-        let profile_source = include_str!("services/profile_operations.rs");
+        let profile_source =
+            normalized_fixture_source(include_str!("services/profile_operations.rs"));
         assert!(profile_source.contains("codex_runtime::CodexReleaseCleanupPolicy::ManagedOnly"));
         assert!(!profile_source.contains("CodexReleaseCleanupPolicy::VerifiedOlderThan"));
     }
@@ -2287,7 +2292,7 @@ printf 'CODEXHUB_TEST_NATIVE_HELPERS=ok\n'
             assert!(locked.contains("trap 'exit 143' TERM"));
         }
 
-        let host_source = include_str!("services/host_operations.rs");
+        let host_source = normalized_fixture_source(include_str!("services/host_operations.rs"));
         for required in [
             "with_remote_codex_runtime_writer_lock(CODEX_UNINSTALL_SCRIPT)",
             "CODEX_OFFICIAL_INSTALL_SCRIPT\n                    )",

--- a/src-tauri/src/services/codex_runtime.rs
+++ b/src-tauri/src/services/codex_runtime.rs
@@ -1740,8 +1740,13 @@ if [ -e "$target_file" ] || [ -L "$target_file" ]; then
     legacy_release_entry=$verified_release_entry
     legacy_release_version=$verified_release_version
     legacy_binary_relative_path=$verified_binary_relative_path
-    select_verified_current_binary || fail_runtime current-release-identity-unknown
-    normalized_target_file_value="$standalone_current"
+    # A missing current link must not hide a separately verified legacy target.
+    # Existing invalid current state was already rejected above.
+    if select_verified_current_binary; then
+      normalized_target_file_value="$standalone_current"
+    else
+      normalized_target_file_value="$target_file_value"
+    fi
   else
     is_valid_executable_target "$target_file_value" || fail_runtime target-file-identity-unknown
     normalized_target_file_value="$target_file_value"
@@ -5330,7 +5335,7 @@ rm -rf "$root"
         })
         .expect("manual pre-login result");
         assert_eq!(parsed.status, CodexRuntimeReconcileStatus::ManualRequired);
-        assert_eq!(parsed.reason, "selected-target-below-pre-login-runtime");
+        assert_eq!(parsed.reason, "selected-target-below-locked-runtime");
         assert!(output.stdout.contains("CODEXHUB_TEST_LAUNCHER=absent"));
     }
 
@@ -5551,7 +5556,7 @@ CODEXHUB_RECONCILE_SCRIPT
 HOME="$home" SHELL=/bin/sh PATH="$home/.local/bin:$PATH" sh "$root/reconcile.sh" >"$root/out"
 cat "$root/out"
 printf 'CODEXHUB_TEST_CURRENT=%s\n' "$(readlink -f "$home/.codex/packages/standalone/current")"
-printf 'CODEXHUB_TEST_VERSION=%s\n' "$("$home/.local/bin/codex" --version | awk '{ print $NF }')"
+printf 'CODEXHUB_TEST_VERSION=%s\n' "$(HOME="$home" "$home/.local/bin/codex" --version | awk '{ print $NF }')"
 rm -rf "$root"
 "###
             .replace("__CURRENT_SETUP__", current_setup)
@@ -7010,23 +7015,42 @@ ln -s "$releases/0.141.0-x86_64-unknown-linux-musl/codex" \
 mkdir -p "$home/proc/321"
 uid=$(id -u)
 printf 'Uid:\t%s\t%s\t%s\t%s\n' "$uid" "$uid" "$uid" "$uid" >"$home/proc/321/status"
-printf '321 (codex) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1001\n' >"$home/proc/321/stat"
+printf '321 (codex) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1001\n' >"$home/proc/321/stat"
 ln -s "$releases/0.142.0/bin/codex" "$home/proc/321/exe"
+set +e
 HOME="$home" sh "$root/update-cleanup.sh" >"$root/first.out"
+first_status=$?
+set -e
+if [ "$first_status" -ne 0 ]; then
+  cat "$root/first.out"
+  exit "$first_status"
+fi
 backup=""
 for item in "$hub"/deletion-backups/update-*; do
   [ -d "$item" ] || continue
   [ -z "$backup" ] || exit 92
   backup=$item
 done
-[ -n "$backup" ]
+if [ -z "$backup" ]; then
+  cat "$root/first.out"
+  exit 93
+fi
 if [ "$(sed -n '1p' "$releases/0.142.0/.codexhub-managed-release" 2>/dev/null)" = "CodexHub managed standalone release v1" ]; then
   in_use_marker=valid
 else
   in_use_marker=missing
 fi
 rm -rf "$home/proc/321"
+set +e
 HOME="$home" sh "$root/managed-cleanup.sh" >"$root/second.out"
+second_status=$?
+set -e
+if [ "$second_status" -ne 0 ]; then
+  cat "$root/first.out"
+  printf '%s\n' CODEXHUB_TEST_SECOND_RUN
+  cat "$root/second.out"
+  exit "$second_status"
+fi
 cat "$root/first.out"
 printf '%s\n' CODEXHUB_TEST_SECOND_RUN
 cat "$root/second.out"
@@ -7087,7 +7111,8 @@ rm -rf "$root"
         };
         assert!(
             output.success(),
-            "update cleanup fixture failed: {}",
+            "update cleanup fixture failed: stdout={} stderr={}",
+            output.stdout,
             output.stderr
         );
         let (first, second) = output


### PR DESCRIPTION
## Summary
- allow a strictly verified legacy runtime target to reconcile when `standalone/current` is absent
- align Linux shell fixtures with writer-lock precedence and fixture HOME semantics
- correct the fake `/proc/<pid>/stat` identity and improve cleanup fixture diagnostics
- normalize CRLF before source-order assertions on Windows

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml` (240 passed)
- `pnpm test` (69 UI tests plus API/bindings/i18n/smoke/typecheck passed)
- `pnpm build:web`
- `pnpm audit:public`
- `git diff --check`